### PR TITLE
[Feat] Uses `ubuntu-router` container image

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,4 +26,4 @@ juju deploy sdcore-router --trust
 
 ## Image
 
-- **router**: `opencord/quagga`
+- **router**: `ghcr.io/canonical/ubuntu-router:0.1`

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -13,7 +13,7 @@ resources:
   router-image:
     type: oci-image
     description: OCI image for SD-Core's router
-    upstream-source: opencord/quagga
+    upstream-source: ghcr.io/canonical/ubuntu-router:0.1
 
 assumes:
   - k8s-api

--- a/src/charm.py
+++ b/src/charm.py
@@ -181,7 +181,7 @@ class RouterOperatorCharm(CharmBase):
         Masks requests with the IP address of the firewall's eth0 interface.
         """
         self._exec_command_in_workload(
-            command="iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE"
+            command="iptables-legacy -t nat -A POSTROUTING -o eth0 -j MASQUERADE"
         )
         logger.info("Successfully set ip tables")
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -72,7 +72,7 @@ class TestCharm(unittest.TestCase):
 
         patch_exec.assert_any_call(
             command=[
-                "iptables",
+                "iptables-legacy",
                 "-t",
                 "nat",
                 "-A",


### PR DESCRIPTION
# Description

Uses [ubuntu-router ROCK](https://github.com/canonical/ubuntu-router-rock) container image instead of [opencord/quagga](https://github.com/opencord/quagga/blob/master/Dockerfile). The `quagga`  image did not receive updates in the last 6 years, it was based on ubuntu-14:04 and we didn't use any of the binaries in it except iptables.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library