### PR TITLE
Allow specifying host interface to use for multus interfaces

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,12 +1,21 @@
 options:
+  core-interface:
+    type: string
+    description: Host interface to use for the Core Network.
   core-gateway-ip:
     type: string
     default: 192.168.250.1/24
     description: Gateway IP address to the Core Network.
+  access-interface:
+    type: string
+    description: Host interface to use for the Access Network.
   access-gateway-ip:
     type: string
     default: 192.168.252.1/24
     description: Gateway IP address to the Access Network.
+  ran-interface:
+    type: string
+    description: Host interface to use for the RAN Network.
   ran-gateway-ip:
     type: string
     default: 192.168.251.1/24


### PR DESCRIPTION
# Description

By default, a `macvlan` interface will use the underlying host's interface with the default gateway. When following the tutorial, all interfaces share the same underlying host's interface.

However, it prevents connectivity with the outside world for real world scenario, like connecting a real `gNodeB`, or deploying the `UPF` on the edge, away from the core.

This change allows specifying what host interface to use for each multus interfaces, allowing the operator to expose the `UPF` to external networks.

When not specifying interfaces, `multus` interfaces will be created with the `bridge` plugin, separating the network traffic in different networks.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library