### PR TITLE
TELCO-729: MTU support

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -2,10 +2,11 @@ options:
   core-interface:
     type: string
     description: Host interface to use for the Core Network.
-  core-interface-mtu:
+  core-interface-mtu-size:
     type: int
-    default: 1500
-    description: MTU to use for the Core Network interface
+    description: |
+      MTU for the core interface (1200 <= MTU <= 65535) in bytes.
+      If not specified, Multus will use its default value (typically 1500).
   core-gateway-ip:
     type: string
     default: 192.168.250.1/24
@@ -13,10 +14,11 @@ options:
   access-interface:
     type: string
     description: Host interface to use for the Access Network.
-  access-interface-mtu:
+  access-interface-mtu-size:
     type: int
-    default: 1500
-    description: MTU to use for the Access Network interface
+    description: |
+      MTU for the core interface (1200 <= MTU <= 65535) in bytes.
+      If not specified, Multus will use its default value (typically 1500).
   access-gateway-ip:
     type: string
     default: 192.168.252.1/24
@@ -24,10 +26,11 @@ options:
   ran-interface:
     type: string
     description: Host interface to use for the RAN Network.
-  ran-interface-mtu:
+  ran-interface-mtu-size:
     type: int
-    default: 1500
-    description: MTU to use for the RAN Network interface
+    description: |
+      MTU for the core interface (1200 <= MTU <= 65535) in bytes.
+      If not specified, Multus will use its default value (typically 1500).
   ran-gateway-ip:
     type: string
     default: 192.168.251.1/24

--- a/config.yaml
+++ b/config.yaml
@@ -2,6 +2,10 @@ options:
   core-interface:
     type: string
     description: Host interface to use for the Core Network.
+  core-interface-mtu:
+    type: int
+    default: 1500
+    description: MTU to use for the Core Network interface
   core-gateway-ip:
     type: string
     default: 192.168.250.1/24
@@ -9,6 +13,10 @@ options:
   access-interface:
     type: string
     description: Host interface to use for the Access Network.
+  access-interface-mtu:
+    type: int
+    default: 1500
+    description: MTU to use for the Access Network interface
   access-gateway-ip:
     type: string
     default: 192.168.252.1/24
@@ -16,6 +24,10 @@ options:
   ran-interface:
     type: string
     description: Host interface to use for the RAN Network.
+  ran-interface-mtu:
+    type: int
+    default: 1500
+    description: MTU to use for the RAN Network interface
   ran-gateway-ip:
     type: string
     default: 192.168.251.1/24

--- a/src/charm.py
+++ b/src/charm.py
@@ -229,7 +229,7 @@ class RouterOperatorCharm(CharmBase):
         return self.model.config.get("core-interface")
 
     def _get_core_interface_mtu_config(self) -> int:
-        return self.model.config.get("core-interface-mtu")
+        return self.model.config.get("core-interface-mtu")  # type: ignore
 
     def _get_core_gateway_ip_config(self) -> Optional[str]:
         return self.model.config.get("core-gateway-ip")
@@ -238,7 +238,7 @@ class RouterOperatorCharm(CharmBase):
         return self.model.config.get("access-interface")
 
     def _get_access_interface_mtu_config(self) -> int:
-        return self.model.config.get("access-interface-mtu")
+        return self.model.config.get("access-interface-mtu")  # type: ignore
 
     def _get_access_gateway_ip_config(self) -> Optional[str]:
         return self.model.config.get("access-gateway-ip")
@@ -247,7 +247,7 @@ class RouterOperatorCharm(CharmBase):
         return self.model.config.get("ran-interface")
 
     def _get_ran_interface_mtu_config(self) -> int:
-        return self.model.config.get("ran-interface-mtu")
+        return self.model.config.get("ran-interface-mtu")  # type: ignore
 
     def _get_ran_gateway_ip_config(self) -> Optional[str]:
         return self.model.config.get("ran-gateway-ip")

--- a/src/charm.py
+++ b/src/charm.py
@@ -7,7 +7,7 @@
 import ipaddress
 import json
 import logging
-from typing import Optional
+from typing import Any, Dict, Optional
 
 from charms.kubernetes_charm_libraries.v0.multus import (  # type: ignore[import]
     KubernetesMultusCharmLib,
@@ -15,7 +15,8 @@ from charms.kubernetes_charm_libraries.v0.multus import (  # type: ignore[import
     NetworkAttachmentDefinition,
 )
 from lightkube.models.meta_v1 import ObjectMeta
-from ops.charm import CharmBase, EventBase
+from ops import EventSource
+from ops.charm import CharmBase, CharmEvents, EventBase
 from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 
@@ -27,10 +28,27 @@ RAN_GW_NAD_NAME = "ran-gw"
 CORE_INTERFACE_NAME = "core"
 ACCESS_INTERFACE_NAME = "access"
 RAN_INTERFACE_NAME = "ran"
+ACCESS_INTERFACE_BRIDGE_NAME = "access-br"
+CORE_INTERFACE_BRIDGE_NAME = "core-br"
+ACESS_INTERFACE_BRIDGE_NAME = "access-br"
+RAN_INTERFACE_BRIDGE_NAME = "ran-br"
+CNI_VERSION = "0.3.1"
+
+
+class NadConfigChangedEvent(EventBase):
+    """Event triggered when an existing network attachment definition is changed."""
+
+
+class KubernetesMultusCharmEvents(CharmEvents):
+    """Kubernetes Multus charm events."""
+
+    nad_config_changed = EventSource(NadConfigChangedEvent)
 
 
 class RouterOperatorCharm(CharmBase):
     """Charm the service."""
+
+    on = KubernetesMultusCharmEvents()
 
     def __init__(self, *args):
         super().__init__(*args)
@@ -56,6 +74,7 @@ class RouterOperatorCharm(CharmBase):
                 ),
             ],
             network_attachment_definitions_func=self._network_attachment_definitions_from_config,
+            refresh_event=self.on.nad_config_changed,
         )
         self.framework.observe(self.on.router_pebble_ready, self._configure)
         self.framework.observe(self.on.config_changed, self._configure)
@@ -67,6 +86,7 @@ class RouterOperatorCharm(CharmBase):
                 f"The following configurations are not valid: {invalid_configs}"
             )
             return
+        self.on.nad_config_changed.emit()
         if not self._container.can_connect():
             self.unit.status = WaitingStatus("Waiting for workload container to be ready")
             event.defer()
@@ -91,6 +111,12 @@ class RouterOperatorCharm(CharmBase):
             invalid_configs.append("ue-subnet")
         if not self._upf_core_ip_is_valid():
             invalid_configs.append("upf-core-ip")
+        if not self._access_interface_mtu_size_is_valid():
+            invalid_configs.append("access-interface-mtu-size")
+        if not self._core_interface_mtu_size_is_valid():
+            invalid_configs.append("core-interface-mtu-size")
+        if not self._ran_interface_mtu_size_is_valid():
+            invalid_configs.append("ran-interface-mtu-size")
         return invalid_configs
 
     def _exec_command_in_workload(self, command: str) -> tuple:
@@ -106,63 +132,29 @@ class RouterOperatorCharm(CharmBase):
         return process.wait_output()
 
     def _network_attachment_definitions_from_config(self) -> list[NetworkAttachmentDefinition]:
-        core_nad_config = {
-            "cniVersion": "0.3.1",
-            "ipam": {
-                "type": "static",
-                "routes": [
-                    {
-                        "dst": self._get_ue_subnet_config(),
-                        "gw": self._get_upf_core_ip_config(),
-                    }
-                ],
-                "addresses": [
-                    {
-                        "address": self._get_core_gateway_ip_config(),
-                    }
-                ],
-            },
-            "mtu": self._get_core_interface_mtu_config(),
-            "capabilities": {"mac": True},
-        }
+        """Returns list of Multus NetworkAttachmentDefinitions to be created based on config.
+
+        Returns:
+            network_attachment_definitions: list[NetworkAttachmentDefinition]
+
+        """
+        core_nad_config = self._get_core_nad_config()
         if (core_interface := self._get_core_interface_config()) is not None:
             core_nad_config.update({"type": "macvlan", "master": core_interface})
         else:
-            core_nad_config.update({"type": "bridge", "bridge": "core-br"})
-        ran_nad_config = {
-            "cniVersion": "0.3.1",
-            "ipam": {
-                "type": "static",
-                "addresses": [
-                    {
-                        "address": self._get_ran_gateway_ip_config(),
-                    }
-                ],
-            },
-            "mtu": self._get_ran_interface_mtu_config(),
-            "capabilities": {"mac": True},
-        }
+            core_nad_config.update({"type": "bridge", "bridge": CORE_INTERFACE_BRIDGE_NAME})
+
+        ran_nad_config = self._get_ran_nad_config()
         if (ran_interface := self._get_ran_interface_config()) is not None:
             ran_nad_config.update({"type": "macvlan", "master": ran_interface})
         else:
-            ran_nad_config.update({"type": "bridge", "bridge": "ran-br"})
-        access_nad_config = {
-            "cniVersion": "0.3.1",
-            "ipam": {
-                "type": "static",
-                "addresses": [
-                    {
-                        "address": self._get_access_gateway_ip_config(),
-                    }
-                ],
-            },
-            "mtu": self._get_access_interface_mtu_config(),
-            "capabilities": {"mac": True},
-        }
+            ran_nad_config.update({"type": "bridge", "bridge": RAN_INTERFACE_BRIDGE_NAME})
+
+        access_nad_config = self._get_access_nad_config()
         if (access_interface := self._get_access_interface_config()) is not None:
             access_nad_config.update({"type": "macvlan", "master": access_interface})
         else:
-            access_nad_config.update({"type": "bridge", "bridge": "access-br"})
+            access_nad_config.update({"type": "bridge", "bridge": ACESS_INTERFACE_BRIDGE_NAME})
         return [
             NetworkAttachmentDefinition(
                 metadata=ObjectMeta(name=CORE_GW_NAD_NAME),
@@ -177,6 +169,78 @@ class RouterOperatorCharm(CharmBase):
                 spec={"config": json.dumps(access_nad_config)},
             ),
         ]
+
+    def _get_core_nad_config(self) -> Dict[Any, Any]:
+        """Get core interface NAD config.
+
+        Returns:
+            config (dict): Core interface NAD config
+        """
+        config = {
+            "cniVersion": CNI_VERSION,
+            "ipam": {
+                "type": "static",
+                "routes": [
+                    {
+                        "dst": self._get_ue_subnet_config(),
+                        "gw": self._get_upf_core_ip_config(),
+                    }
+                ],
+                "addresses": [
+                    {
+                        "address": self._get_core_gateway_ip_config(),
+                    }
+                ],
+            },
+            "capabilities": {"mac": True},
+        }
+        if core_mtu := self._get_core_interface_mtu_config():
+            config.update({"mtu": core_mtu})
+        return config
+
+    def _get_ran_nad_config(self) -> Dict[Any, Any]:
+        """Get RAN interface NAD config.
+
+        Returns:
+            config (dict): RAN interface NAD config
+        """
+        config = {
+            "cniVersion": CNI_VERSION,
+            "ipam": {
+                "type": "static",
+                "addresses": [
+                    {
+                        "address": self._get_ran_gateway_ip_config(),
+                    }
+                ],
+            },
+            "capabilities": {"mac": True},
+        }
+        if ran_mtu := self._get_ran_interface_mtu_config():
+            config.update({"mtu": ran_mtu})
+        return config
+
+    def _get_access_nad_config(self) -> Dict[Any, Any]:
+        """Get access interface NAD config.
+
+        Returns:
+            config (dict): Access interface NAD config
+        """
+        config = {
+            "cniVersion": CNI_VERSION,
+            "ipam": {
+                "type": "static",
+                "addresses": [
+                    {
+                        "address": self._get_access_gateway_ip_config(),
+                    }
+                ],
+            },
+            "capabilities": {"mac": True},
+        }
+        if access_mtu := self._get_access_interface_mtu_config():
+            config.update({"mtu": access_mtu})
+        return config
 
     def _set_ip_tables(self) -> None:
         """Configures firewall for IP masquerading.
@@ -225,11 +289,56 @@ class RouterOperatorCharm(CharmBase):
             return False
         return ip_is_valid(ip)
 
+    def _core_interface_mtu_size_is_valid(self) -> bool:
+        """Checks whether the core interface MTU size is valid.
+
+        Returns:
+            bool: Whether core interface MTU size is valid
+        """
+        if (core_mtu := self._get_core_interface_mtu_config()) is None:
+            return True
+        try:
+            return 1200 <= int(core_mtu) <= 65535
+        except ValueError:
+            return False
+
+    def _access_interface_mtu_size_is_valid(self) -> bool:
+        """Checks whether the access interface MTU size is valid.
+
+        Returns:
+            bool: Whether access interface MTU size is valid
+        """
+        if (access_mtu := self._get_access_interface_mtu_config()) is None:
+            return True
+        try:
+            return 1200 <= int(access_mtu) <= 65535
+        except ValueError:
+            return False
+
+    def _ran_interface_mtu_size_is_valid(self) -> bool:
+        """Checks whether the RAN interface MTU size is valid.
+
+        Returns:
+            bool: Whether RAN interface MTU size is valid
+        """
+        if (ran_mtu := self._get_ran_interface_mtu_config()) is None:
+            return True
+        try:
+            return 1200 <= int(ran_mtu) <= 65535
+        except ValueError:
+            return False
+
     def _get_core_interface_config(self) -> Optional[str]:
         return self.model.config.get("core-interface")
 
-    def _get_core_interface_mtu_config(self) -> int:
-        return self.model.config.get("core-interface-mtu")  # type: ignore
+    def _get_core_interface_mtu_config(self) -> Optional[str]:
+        """Get Core interface MTU size.
+
+        Returns:
+            mtu_size (str/None): If MTU size is not configured return None
+                                If it is set, returns the configured value
+        """
+        return self.model.config.get("core-interface-mtu-size")
 
     def _get_core_gateway_ip_config(self) -> Optional[str]:
         return self.model.config.get("core-gateway-ip")
@@ -237,8 +346,14 @@ class RouterOperatorCharm(CharmBase):
     def _get_access_interface_config(self) -> Optional[str]:
         return self.model.config.get("access-interface")
 
-    def _get_access_interface_mtu_config(self) -> int:
-        return self.model.config.get("access-interface-mtu")  # type: ignore
+    def _get_access_interface_mtu_config(self) -> Optional[str]:
+        """Get access interface MTU size.
+
+        Returns:
+            mtu_size (str/None): If MTU size is not configured return None
+                                If it is set, returns the configured value
+        """
+        return self.model.config.get("access-interface-mtu-size")
 
     def _get_access_gateway_ip_config(self) -> Optional[str]:
         return self.model.config.get("access-gateway-ip")
@@ -246,8 +361,14 @@ class RouterOperatorCharm(CharmBase):
     def _get_ran_interface_config(self) -> Optional[str]:
         return self.model.config.get("ran-interface")
 
-    def _get_ran_interface_mtu_config(self) -> int:
-        return self.model.config.get("ran-interface-mtu")  # type: ignore
+    def _get_ran_interface_mtu_config(self) -> Optional[str]:
+        """Get RAN interface MTU size.
+
+        Returns:
+            mtu_size (str/None): If MTU size is not configured return None
+                                If it is set, returns the configured value
+        """
+        return self.model.config.get("ran-interface-mtu-size")
 
     def _get_ran_gateway_ip_config(self) -> Optional[str]:
         return self.model.config.get("ran-gateway-ip")

--- a/src/charm.py
+++ b/src/charm.py
@@ -30,7 +30,6 @@ ACCESS_INTERFACE_NAME = "access"
 RAN_INTERFACE_NAME = "ran"
 ACCESS_INTERFACE_BRIDGE_NAME = "access-br"
 CORE_INTERFACE_BRIDGE_NAME = "core-br"
-ACESS_INTERFACE_BRIDGE_NAME = "access-br"
 RAN_INTERFACE_BRIDGE_NAME = "ran-br"
 CNI_VERSION = "0.3.1"
 
@@ -154,7 +153,7 @@ class RouterOperatorCharm(CharmBase):
         if (access_interface := self._get_access_interface_config()) is not None:
             access_nad_config.update({"type": "macvlan", "master": access_interface})
         else:
-            access_nad_config.update({"type": "bridge", "bridge": ACESS_INTERFACE_BRIDGE_NAME})
+            access_nad_config.update({"type": "bridge", "bridge": ACCESS_INTERFACE_BRIDGE_NAME})
         return [
             NetworkAttachmentDefinition(
                 metadata=ObjectMeta(name=CORE_GW_NAD_NAME),

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -60,7 +60,7 @@ class TestCharm(unittest.TestCase):
             WaitingStatus("Waiting for workload container to be ready"),
         )
 
-    @patch("charms.kubernetes_charm_libraries.v0.multus.KubernetesMultusCharmLib.is_ready")
+    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_multus_not_ready_when_config_changed_then_status_is_waiting(
         self, patch_is_ready
     ):
@@ -75,7 +75,7 @@ class TestCharm(unittest.TestCase):
         )
 
     @patch("ops.model.Container.exec")
-    @patch("charms.kubernetes_charm_libraries.v0.multus.KubernetesMultusCharmLib.is_ready")
+    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_multus_is_ready_when_config_changed_then_ip_forwarding_is_set(
         self, patch_is_ready, patch_exec
     ):
@@ -90,7 +90,7 @@ class TestCharm(unittest.TestCase):
         patch_exec.assert_any_call(command=["sysctl", "-w", "net.ipv4.ip_forward=1"], timeout=30)
 
     @patch("ops.model.Container.exec")
-    @patch("charms.kubernetes_charm_libraries.v0.multus.KubernetesMultusCharmLib.is_ready")
+    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_multus_is_ready_when_config_changed_then_iptables_rule_is_set(
         self, patch_is_ready, patch_exec
     ):
@@ -118,7 +118,7 @@ class TestCharm(unittest.TestCase):
         )
 
     @patch("ops.model.Container.exec")
-    @patch("charms.kubernetes_charm_libraries.v0.multus.KubernetesMultusCharmLib.is_ready")
+    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_error_when_setting_ip_forwarding_when_config_changed_then_runtime_error_is_raised(  # noqa: E501
         self, patch_is_ready, patch_exec
     ):
@@ -137,7 +137,7 @@ class TestCharm(unittest.TestCase):
         )
 
     @patch("ops.model.Container.exec")
-    @patch("charms.kubernetes_charm_libraries.v0.multus.KubernetesMultusCharmLib.is_ready")
+    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_ip_forwarding_set_correctly_when_config_changed_then_status_is_active(
         self, patch_is_ready, patch_exec
     ):
@@ -151,7 +151,7 @@ class TestCharm(unittest.TestCase):
 
         self.assertEqual(self.harness.model.unit.status, ActiveStatus())
 
-    @patch("charms.kubernetes_charm_libraries.v0.multus.KubernetesMultusCharmLib.is_ready")
+    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_empty_ip_when_config_changed_then_status_is_blocked(self, patch_is_ready):
         patch_is_ready.return_value = True
         self.harness.set_can_connect(container="router", val=True)
@@ -163,10 +163,10 @@ class TestCharm(unittest.TestCase):
             BlockedStatus("The following configurations are not valid: ['core-gateway-ip']"),
         )
 
-    @patch("charms.kubernetes_charm_libraries.v0.multus.KubernetesMultusCharmLib.is_ready")
+    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_invalid_non_cidr_ip_when_config_changed_then_status_is_blocked(
         self, patch_is_ready
-    ):  # noqa: E501
+    ):
         patch_is_ready.return_value = True
         self.harness.set_can_connect(container="router", val=True)
 
@@ -188,7 +188,7 @@ class TestCharm(unittest.TestCase):
             ),
         )
 
-    @patch("charms.kubernetes_charm_libraries.v0.multus.KubernetesMultusCharmLib.is_ready")
+    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_ip_in_cidr_format_with_too_big_mask_when_config_changed_then_status_is_blocked(
         self, patch_is_ready
     ):
@@ -209,7 +209,7 @@ class TestCharm(unittest.TestCase):
             BlockedStatus("The following configurations are not valid: ['access-gateway-ip']"),
         )
 
-    @patch("charms.kubernetes_charm_libraries.v0.multus.KubernetesMultusCharmLib.is_ready")
+    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_gateway_ip_in_cidr_format_with_too_small_mask_when_config_changed_then_status_is_blocked(  # noqa: E501
         self, patch_is_ready
     ):
@@ -232,7 +232,7 @@ class TestCharm(unittest.TestCase):
             ),
         )
 
-    @patch("charms.kubernetes_charm_libraries.v0.multus.KubernetesMultusCharmLib.is_ready")
+    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_string_gateway_ip_when_config_changed_then_status_is_blocked(
         self, patch_is_ready
     ):
@@ -293,14 +293,14 @@ class TestCharm(unittest.TestCase):
             self.assertEqual(config["master"], nad.metadata.name)
             self.assertEqual(config["type"], "macvlan")
 
-    def test_given_default_config__when_network_attachment_definitions_from_config_is_called_then_no_mtu_specified_in_nad(  # noqa: E501
+    def test_given_default_config_when_network_attachment_definitions_from_config_is_called_then_no_mtu_specified_in_nad(  # noqa: E501
         self,
     ):
         self.harness.update_config(
             key_values={
-                "access-gateway-ip": "192.168.252.1",
-                "core-gateway-ip": "192.168.250.1",
-                "ran-gateway-ip": "192.168.251.1",
+                "access-gateway-ip": ACCESS_GATEWAY_IP,
+                "core-gateway-ip": CORE_GATEWAY_IP,
+                "ran-gateway-ip": RAN_GATEWAY_IP,
             }
         )
         nads = self.harness.charm._network_attachment_definitions_from_config()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -259,16 +259,16 @@ class TestCharm(unittest.TestCase):
     def test_given_default_config_when_network_attachment_definitions_from_config_is_called_then_mtu_specified_in_nad(  # noqa: E501
         self,
     ):
-        CUSTOM_MTU = 9000
+        custom_mtu = 9000
         self.harness.disable_hooks()
         self.harness.update_config(
             key_values={
-                "access-interface-mtu": CUSTOM_MTU,
+                "access-interface-mtu": custom_mtu,
                 "access-gateway-ip": "192.168.252.1",
-                "core-interface-mtu": CUSTOM_MTU,
+                "core-interface-mtu": custom_mtu,
                 "core-gateway-ip": "192.168.250.1",
                 "ran-gateway-ip": "192.168.251.1",
-                "ran-interface-mtu": CUSTOM_MTU,
+                "ran-interface-mtu": custom_mtu,
             }
         )
         nads = self.harness.charm._network_attachment_definitions_from_config()
@@ -276,7 +276,7 @@ class TestCharm(unittest.TestCase):
             config = json.loads(nad.spec["config"])
             self.assertNotIn("master", config)
             self.assertEqual("bridge", config["type"])
-            self.assertEqual(CUSTOM_MTU, config["mtu"])
+            self.assertEqual(custom_mtu, config["mtu"])
             self.assertIn(config["bridge"], ("access-br", "core-br", "ran-br"))
 
     def test_given_default_config_with_interfaces_when_network_attachment_definitions_from_config_is_called_then_interfaces_specified_in_nad(  # noqa: E501

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -237,7 +237,7 @@ class TestCharm(unittest.TestCase):
             ),
         )
 
-    def test_given_default_config_when_network_attachment_definitions_from_config_is_called_then_no_interface_specified_in_nad(  # noqa: E501
+    def test_given_default_config_when_network_attachment_definitions_from_config_is_called_then_no_interface_or_mtu_specified_in_nad(  # noqa: E501
         self,
     ):
         self.harness.disable_hooks()
@@ -253,6 +253,30 @@ class TestCharm(unittest.TestCase):
             config = json.loads(nad.spec["config"])
             self.assertNotIn("master", config)
             self.assertEqual("bridge", config["type"])
+            self.assertEqual(1500, config["mtu"])
+            self.assertIn(config["bridge"], ("access-br", "core-br", "ran-br"))
+
+    def test_given_default_config_when_network_attachment_definitions_from_config_is_called_then_mtu_specified_in_nad(  # noqa: E501
+        self,
+    ):
+        CUSTOM_MTU = 9000
+        self.harness.disable_hooks()
+        self.harness.update_config(
+            key_values={
+                "access-interface-mtu": CUSTOM_MTU,
+                "access-gateway-ip": "192.168.252.1",
+                "core-interface-mtu": CUSTOM_MTU,
+                "core-gateway-ip": "192.168.250.1",
+                "ran-gateway-ip": "192.168.251.1",
+                "ran-interface-mtu": CUSTOM_MTU,
+            }
+        )
+        nads = self.harness.charm._network_attachment_definitions_from_config()
+        for nad in nads:
+            config = json.loads(nad.spec["config"])
+            self.assertNotIn("master", config)
+            self.assertEqual("bridge", config["type"])
+            self.assertEqual(CUSTOM_MTU, config["mtu"])
             self.assertIn(config["bridge"], ("access-br", "core-br", "ran-br"))
 
     def test_given_default_config_with_interfaces_when_network_attachment_definitions_from_config_is_called_then_interfaces_specified_in_nad(  # noqa: E501


### PR DESCRIPTION
# Description

- Adding optional configuration to set custom MTU sizes for Router access, core and ran interfaces.
- Validates MTU config settings before changing multus NADs
-  Pod is restarted by the multus library if NAD has changed to make the new configuration effective

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library