### PR TITLE
Validate config values which requested in CIDR notation.

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -5,25 +5,25 @@ options:
   core-gateway-ip:
     type: string
     default: 192.168.250.1/24
-    description: Gateway IP address to the Core Network.
+    description: Gateway IP address in CIDR format to the Core Network.
   access-interface:
     type: string
     description: Host interface to use for the Access Network.
   access-gateway-ip:
     type: string
     default: 192.168.252.1/24
-    description: Gateway IP address to the Access Network.
+    description: Gateway IP address in CIDR format to the Access Network.
   ran-interface:
     type: string
     description: Host interface to use for the RAN Network.
   ran-gateway-ip:
     type: string
     default: 192.168.251.1/24
-    description: Gateway IP address to the RAN Network.
+    description: Gateway IP address in CIDR format to the RAN Network.
   ue-subnet:
     type: string
     default: 172.250.0.0/16
-    description: Subnet used by User Equipments
+    description: Subnet used by User Equipments in CIDR format
   upf-core-ip:
     type: string
     default: 192.168.250.3

--- a/src/charm.py
+++ b/src/charm.py
@@ -273,7 +273,7 @@ def ip_in_cidr_format_is_valid(ip_address: str) -> bool:
         bool: True if given IP address is valid
     """
     if "/" not in ip_address:
-        logger.warning(f"The IP address: {ip_address} is expected in CIDR format.")
+        logger.error("The IP address: %s is expected in CIDR format.", ip_address)
         return False
     return ip_is_valid(ip_address)
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -196,25 +196,25 @@ class RouterOperatorCharm(CharmBase):
         ip = self._get_core_gateway_ip_config()
         if not ip:
             return False
-        return ip_is_valid(ip)
+        return ip_in_cidr_format_is_valid(ip)
 
     def _access_gateway_ip_is_valid(self) -> bool:
         ip = self._get_access_gateway_ip_config()
         if not ip:
             return False
-        return ip_is_valid(ip)
+        return ip_in_cidr_format_is_valid(ip)
 
     def _ran_gateway_ip_is_valid(self) -> bool:
         ip = self._get_ran_gateway_ip_config()
         if not ip:
             return False
-        return ip_is_valid(ip)
+        return ip_in_cidr_format_is_valid(ip)
 
     def _ue_subnet_is_valid(self) -> bool:
         ip = self._get_ue_subnet_config()
         if not ip:
             return False
-        return ip_is_valid(ip)
+        return ip_in_cidr_format_is_valid(ip)
 
     def _upf_core_ip_is_valid(self) -> bool:
         ip = self._get_upf_core_ip_config()
@@ -261,6 +261,21 @@ def ip_is_valid(ip_address: str) -> bool:
         return True
     except ValueError:
         return False
+
+
+def ip_in_cidr_format_is_valid(ip_address: str) -> bool:
+    """Check whether given IP config is in CIDR format and valid.
+
+    Args:
+        ip_address (str): IP address in CIDR format
+
+    Returns:
+        bool: True if given IP address is valid
+    """
+    if "/" not in ip_address:
+        logger.warning(f"The IP address: {ip_address} is expected in CIDR format.")
+        return False
+    return ip_is_valid(ip_address)
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
# Description

This PR adds CIDR format validation to all IP addresses that require it. By this way, if the user accidentally specifies an IP without the subnet, charm will enter into Blocked status, instead of having an error which fails the execution.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library