### PR TITLE
chore: Rename SD-Core charms by adding -k8s as a suffix

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -27,7 +27,7 @@ jobs:
   integration-test:
     uses: canonical/sdcore-github-workflows/.github/workflows/integration-test-with-multus.yaml@main
     with:
-      charm-file-name: "sdcore-router_ubuntu-22.04-amd64.charm"
+      charm-file-name: "sdcore-router-k8s_ubuntu-22.04-amd64.charm"
 
   publish-charm:
     name: Publish Charm
@@ -39,5 +39,5 @@ jobs:
     if: ${{ github.ref_name == 'main' }}
     uses: canonical/sdcore-github-workflows/.github/workflows/publish-charm.yaml@main
     with:
-      charm-file-name: "sdcore-router_ubuntu-22.04-amd64.charm"
+      charm-file-name: "sdcore-router-k8s_ubuntu-22.04-amd64.charm"
     secrets: inherit

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SD-Core Router Operator for K8s
+# SD-Core Router Operator (k8s)
 [![CharmHub Badge](https://charmhub.io/sdcore-router-k8s/badge.svg)](https://charmhub.io/sdcore-router-k8s)
 
 A Charmed Operator for SD-Core's Router for K8s. 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# SD-Core Router Operator (k8s)
-[![CharmHub Badge](https://charmhub.io/sdcore-router/badge.svg)](https://charmhub.io/sdcore-router)
+# SD-Core Router K8s Operator
+[![CharmHub Badge](https://charmhub.io/sdcore-router-k8s/badge.svg)](https://charmhub.io/sdcore-router-k8s)
 
-A Charmed Operator for SD-Core's Router. 
+A Charmed K8s Operator for SD-Core's Router. 
 
 ## Pre-requisites
 
@@ -10,7 +10,7 @@ A Charmed Operator for SD-Core's Router.
 ## Usage
 
 ```bash
-juju deploy sdcore-router --trust
+juju deploy sdcore-router-k8s --trust
 ```
 
 ## Image

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# SD-Core Router K8s Operator
+# SD-Core Router Operator for K8s
 [![CharmHub Badge](https://charmhub.io/sdcore-router-k8s/badge.svg)](https://charmhub.io/sdcore-router-k8s)
 
-A Charmed K8s Operator for SD-Core's Router. 
+A Charmed Operator for SD-Core's Router for K8s. 
 
 ## Pre-requisites
 

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,12 +1,12 @@
-name: sdcore-router
+name: sdcore-router-k8s
 
 display-name: SD-Core router
 summary: A Charmed Operator for SD-Core's router.
 description: |
   A Charmed Operator for SD-Core's router.
-website: https://charmhub.io/sdcore-router
-source: https://github.com/canonical/sdcore-router-operator
-issues: https://github.com/canonical/sdcore-router-operator/issues
+website: https://charmhub.io/sdcore-router-k8s
+source: https://github.com/canonical/sdcore-router-k8s-operator
+issues: https://github.com/canonical/sdcore-router-k8s-operator/issues
 
 containers:
   router:

--- a/src/charm.py
+++ b/src/charm.py
@@ -2,7 +2,7 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""Charmed K8s operator for the SD-Core's router."""
+"""Charmed operator for the SD-Core's router for K8s."""
 
 import ipaddress
 import json
@@ -44,7 +44,7 @@ class KubernetesMultusCharmEvents(CharmEvents):
     nad_config_changed = EventSource(NadConfigChangedEvent)
 
 
-class RouterK8sOperatorCharm(CharmBase):
+class RouterOperatorCharm(CharmBase):
     """Charm the service."""
 
     on = KubernetesMultusCharmEvents()
@@ -411,4 +411,4 @@ def ip_in_cidr_format_is_valid(ip_address: str) -> bool:
 
 
 if __name__ == "__main__":  # pragma: no cover
-    main(RouterK8sOperatorCharm)
+    main(RouterOperatorCharm)

--- a/src/charm.py
+++ b/src/charm.py
@@ -2,7 +2,7 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""Charmed operator for the SD-Core's router."""
+"""Charmed K8s operator for the SD-Core's router."""
 
 import ipaddress
 import json
@@ -44,7 +44,7 @@ class KubernetesMultusCharmEvents(CharmEvents):
     nad_config_changed = EventSource(NadConfigChangedEvent)
 
 
-class RouterOperatorCharm(CharmBase):
+class RouterK8sOperatorCharm(CharmBase):
     """Charm the service."""
 
     on = KubernetesMultusCharmEvents()
@@ -411,4 +411,4 @@ def ip_in_cidr_format_is_valid(ip_address: str) -> bool:
 
 
 if __name__ == "__main__":  # pragma: no cover
-    main(RouterOperatorCharm)
+    main(RouterK8sOperatorCharm)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,6 +4,7 @@ coverage[toml]
 flake8-docstrings
 flake8-builtins
 isort
+macaroonbakery==1.3.2  # https://protobuf.dev/news/2022-05-06/#python-updates
 mypy
 pep8-naming
 pyproject-flake8

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -9,7 +9,7 @@ import pytest
 from ops import testing
 from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 
-from charm import RouterK8sOperatorCharm
+from charm import RouterOperatorCharm
 from lib.charms.kubernetes_charm_libraries.v0.multus import NetworkAttachmentDefinition
 
 ACCESS_GATEWAY_IP = "192.168.252.1"
@@ -46,7 +46,7 @@ def update_nad_labels(nads: list[NetworkAttachmentDefinition], app_name: str) ->
 class TestCharm(unittest.TestCase):
     @patch("lightkube.core.client.GenericSyncClient")
     def setUp(self, patch_k8s_client):
-        self.harness = testing.Harness(RouterK8sOperatorCharm)
+        self.harness = testing.Harness(RouterOperatorCharm)
         self.addCleanup(self.harness.cleanup)
         self.harness.begin()
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -9,7 +9,7 @@ import pytest
 from ops import testing
 from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 
-from charm import RouterOperatorCharm
+from charm import RouterK8sOperatorCharm
 from lib.charms.kubernetes_charm_libraries.v0.multus import NetworkAttachmentDefinition
 
 ACCESS_GATEWAY_IP = "192.168.252.1"
@@ -46,7 +46,7 @@ def update_nad_labels(nads: list[NetworkAttachmentDefinition], app_name: str) ->
 class TestCharm(unittest.TestCase):
     @patch("lightkube.core.client.GenericSyncClient")
     def setUp(self, patch_k8s_client):
-        self.harness = testing.Harness(RouterOperatorCharm)
+        self.harness = testing.Harness(RouterK8sOperatorCharm)
         self.addCleanup(self.harness.cleanup)
         self.harness.begin()
 


### PR DESCRIPTION
# Description

Add -k8s as a suffix in both github and Charmhub name to follow [TE042](https://docs.google.com/document/d/1R0UzoPr3vvorhbBJYBz-5gZkTCTL2a9_R6xV8K4_i-8/edit) . 

- Bump up multus library
- Pin macaroonbakery to 1.3.2 which installed by juju client indirectly through pytest_operator.
      - The next protobuf version 4.21.0 has the breaking changes with the existing code
      - https://protobuf.dev/news/2022-05-06/#python-updates

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library